### PR TITLE
Fixes & --manifest-path argument

### DIFF
--- a/src/arguments.yml
+++ b/src/arguments.yml
@@ -42,3 +42,8 @@ subcommands:
             - mksrcinfo:
                 help: Run mksrcinfo
                 long: mksrcinfo
+            - manifest-path:
+                help: Cargo.toml directory path
+                long: manifest-path
+                short: p
+                takes_value: true

--- a/src/config/arch.rs
+++ b/src/config/arch.rs
@@ -147,12 +147,18 @@ pub struct ArchConfig {
 }
 
 impl ArchConfig {
-    pub fn new() -> ArchConfig {
+    pub fn new(manifest_path: Option<&str>) -> ArchConfig {
         let mut content = String::new();
-        let path = format!("{}/Cargo.toml", match std::env::var("CARGO_MANIFEST_DIR") {
-                Ok(val) => val,
-                Err(_) => ".".to_string(),
-            });
+        let path = format!(
+            "{}/Cargo.toml",
+            match manifest_path {
+                Some(val) => val.to_string(),
+                None => match std::env::var("CARGO_MANIFEST_DIR") {
+                    Ok(val) => val,
+                    Err(_) => ".".to_string(),
+                }
+            }
+        );
         let mut path = File::open(path.as_str()).unwrap();
         path.read_to_string(&mut content)
             .expect("cargo-arch: invalid or missing Cargo.toml options");

--- a/src/config/arch.rs
+++ b/src/config/arch.rs
@@ -149,7 +149,10 @@ pub struct ArchConfig {
 impl ArchConfig {
     pub fn new() -> ArchConfig {
         let mut content = String::new();
-        let path = format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR"));
+        let path = format!("{}/Cargo.toml", match std::env::var("CARGO_MANIFEST_DIR") {
+                Ok(val) => val,
+                Err(_) => ".".to_string(),
+            });
         let mut path = File::open(path.as_str()).unwrap();
         path.read_to_string(&mut content)
             .expect("cargo-arch: invalid or missing Cargo.toml options");
@@ -193,7 +196,7 @@ impl ArchConfig {
         buffer.push_str("\n");
 
         add_data!("pkgname={}\n", self.pkgname);
-        add_data!("pkgver={}\n", self.pkgver);
+        add_data!("pkgver={}\n", self.pkgver.replace("-","_"));
         add_data!("pkgrel={}\n", self.pkgrel);
         add_data!("epoch={}\n", self.epoch);
         add_data!("pkgdesc=\"{}\"\n", self.pkgdesc);

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,14 @@ fn build_arch_package(mksrcinfo: bool,
                       build: bool,
                       install: bool,
                       syncdeps: bool,
-                      force: bool) {
+                      force: bool,
+                      manifest_path: Option<&str>) {
     use std::process::Command;
     use std::fs::File;
     use std::io::Write;
     use crate::config::core::GeneratePackageConfig;
 
-    config::ArchConfig::new().generate_package_config();
+    config::ArchConfig::new(manifest_path).generate_package_config();
 
     if mksrcinfo {
         let output = Command::new("makepkg")
@@ -73,11 +74,12 @@ fn main() {
     let syncdeps = arguments.is_present("syncdeps");
     let force = arguments.is_present("force");
     let mksrcinfo = arguments.is_present("mksrcinfo");
+    let manifest_path = arguments.value_of("manifest-path");
 
     ////////////////////
     // Build Arch Package
     ////////////////////
 
-    build_arch_package(mksrcinfo, build, install, syncdeps, force);
+    build_arch_package(mksrcinfo, build, install, syncdeps, force, manifest_path);
 
 }


### PR DESCRIPTION
`Cargo.toml` directory was found using `env!`, which works at compile time. Fixed with `std::env::var`.

Hyphens are forbidden in `pkgver`. The doc advises to replace them by underscores. Fixed.

Setting `Cargo.toml` path in commandline can be useful. Implemented with `--manifest-path` (like with _cargo-deb_).