### PR TITLE
ensure that the defaults of the arch section are populated

### DIFF
--- a/src/config/meta.rs
+++ b/src/config/meta.rs
@@ -1,11 +1,19 @@
 //! Metadata for different platform's package
 
 use super::arch::CargoArch;
-
+use std::default::Default;
 
 /// data in `[package.metadata]` section
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct CargoMetadata {
     #[serde(default)]
     pub arch: CargoArch,
+}
+
+impl Default for CargoMetadata {
+    // if we do not decode an empty [arch] block then the defaults are
+    // not actually populated
+    fn default() -> Self {
+        toml::from_str("[arch]").unwrap()
+    }
 }


### PR DESCRIPTION
Calling defaults without actually having a section is resulting in none
of the fields being populated properly. Likely a serde bug.