### PR TITLE
Use --no-track flag with cargo install

### DIFF
--- a/src/config/PKGBUILD-TEMPLATE
+++ b/src/config/PKGBUILD-TEMPLATE
@@ -12,6 +12,5 @@ package() {
     cd ..
     usrdir="$pkgdir/usr"
     mkdir -p $usrdir
-    cargo install --path . --root "$usrdir"
-    rm -f $usrdir/.crates.toml
+    cargo install --no-track --path . --root "$usrdir"
 }


### PR DESCRIPTION
While using `cargo-arch`, I noticed that the resulting package also included `/usr/.crates2.json`.

By using the `--no-track` option we don't have to `rm -f .crates.toml .crates2.json` manually.