### PR TITLE
Prevent building the crate twice

### DIFF
--- a/src/config/PKGBUILD-TEMPLATE
+++ b/src/config/PKGBUILD-TEMPLATE
@@ -3,12 +3,10 @@ pkgver() {
 }
 
 build() {
-    export CARGO_TARGET_DIR="${srcdir}/${pkgname}-${pkgver}"
     cargo build --release
 }
 
 package() {
-    export CARGO_TARGET_DIR="${srcdir}/${pkgname}-${pkgver}"
     cd ..
     usrdir="$pkgdir/usr"
     mkdir -p $usrdir

--- a/src/config/PKGBUILD-TEMPLATE
+++ b/src/config/PKGBUILD-TEMPLATE
@@ -3,7 +3,7 @@ pkgver() {
 }
 
 build() {
-    cargo build --release
+    return 0
 }
 
 package() {


### PR DESCRIPTION
I noticed that #9 was not solved for me, and d8e4373e265e00cf64409537361ffed60fbeee8d only had the side effect of makepkg using the src directory in my project as `$srcdir`, which resulted in a build directory alongside source code (at least for me).

I tried to find a way around this but the best solution I could find was to just make the `build()` function do nothing, as the [ArchWiki suggests](https://wiki.archlinux.org/index.php/Rust_package_guidelines#Notes_about_using_cargo_install).

